### PR TITLE
Add GitHub Skills activity to registration system

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the missing GitHub Skills activity that was announced by the principal at the school assembly.

## Changes
- Added "GitHub Skills" as a new extracurricular activity in the activities database
- Set maximum capacity to 25 students
- Schedule: Mondays and Thursdays, 3:30 PM - 5:00 PM
- Includes description mentioning GitHub Certifications program for college applications

## Fixes
Closes #6

## Testing
- ✅ No syntax errors
- ✅ Activity follows same structure as existing activities
- ✅ Ready for student signups

## Impact
This is time-sensitive as registrations close by the end of this week. Students like Hewbie C. (11th grade) have been waiting to sign up for this activity.